### PR TITLE
Add component declaration for `vec4`.

### DIFF
--- a/include/flecs_components_cglm.h
+++ b/include/flecs_components_cglm.h
@@ -12,6 +12,9 @@ FLECS_COMPONENTS_CGLM_API
 extern ECS_COMPONENT_DECLARE(vec3);
 
 FLECS_COMPONENTS_CGLM_API
+extern ECS_COMPONENT_DECLARE(vec4);
+
+FLECS_COMPONENTS_CGLM_API
 void FlecsComponentsCglmImport(
     ecs_world_t *world);
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,7 @@
 #include <flecs_components_cglm.h>
 
 ECS_COMPONENT_DECLARE(vec3);
+ECS_COMPONENT_DECLARE(vec4);
 
 void FlecsComponentsCglmImport(
     ecs_world_t *world)
@@ -15,5 +16,15 @@ void FlecsComponentsCglmImport(
         }),
         .type = ecs_id(ecs_f32_t),
         .count = 3 
+    });
+
+    ecs_id(vec4) = ecs_array(world, {
+        .entity = ecs_entity(world, {
+            .name = "vec4",
+            .symbol = "vec4",
+            .id = ecs_id(vec4)
+        }),
+        .type = ecs_id(ecs_f32_t),
+        .count = 4
     });
 }


### PR DESCRIPTION
This is copied from the tower defense sample, but with a typo fix where it assigned to `ecs_id(vec3)` instead of `ecs_id(vec4)`.